### PR TITLE
Add option to inline items that only have a single child

### DIFF
--- a/bprint.py
+++ b/bprint.py
@@ -23,7 +23,8 @@ def bprint(
         human_bytes=True,
         skip_predicate: typing.Callable[[str, typing.Any], bool] = default_skip_predicate,
         seq_bullet='- ',
-        sep='\n\n'
+        sep='\n\n',
+        inline_singular=False
 ):
     """
     Beautifully prints the given ``values``.
@@ -81,6 +82,10 @@ def bprint(
 
         sep
             The separator to use when there is more than one value.
+
+        inline_singular
+            If True, removes the newline and indent before items if they only
+            have a single value
     """
     if maximum_depth is None:
         maximum_depth = float('inf')
@@ -95,14 +100,18 @@ def bprint(
         out = stream or DEFAULT_STREAM
 
     def handle_kvp(level, kvp):
-        kvp = ((k, v) for k, v in kvp if not skip_predicate(k, v))
+        kvp = [(k, v) for k, v in kvp if not skip_predicate(k, v)]
         if sort:
             kvp = sorted(kvp)
 
         ind = get_indent(level)
+        has_multiple_items = len(kvp) > 1
         for key, value in kvp:
-            out.write('\n')
-            out.write(ind)
+            if not inline_singular or has_multiple_items:
+                out.write('\n')
+                out.write(ind)
+            else:
+                out.write(' ')
             out.write(key)
             out.write(':')
             fmt(value, level, ' ')

--- a/bprint.py
+++ b/bprint.py
@@ -95,17 +95,17 @@ def bprint(
         out = stream or DEFAULT_STREAM
 
     def handle_kvp(level, kvp):
+        kvp = ((k, v) for k, v in kvp if not skip_predicate(k, v))
         if sort:
             kvp = sorted(kvp)
 
         ind = get_indent(level)
         for key, value in kvp:
-            if not skip_predicate(key, value):
-                out.write('\n')
-                out.write(ind)
-                out.write(key)
-                out.write(':')
-                fmt(value, level, ' ')
+            out.write('\n')
+            out.write(ind)
+            out.write(key)
+            out.write(':')
+            fmt(value, level, ' ')
 
     if isinstance(indent, str):
         def get_indent(level):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import re
 from setuptools import setup
 
 
-VERSION = '0.5.1'
+VERSION = '0.5.2'
 
 
 def main():


### PR DESCRIPTION
This makes it possible to turn this

```
Test:
  key: 'value'
  something: Something:
    deeply_nested: DeeplyNested:
      value:
        - 1
        - 2
        - 3
```

into

```
Test:
  key: 'value'
  something: Something: deeply_nested: DeeplyNested: value:
        - 1
        - 2
        - 3
```

by setting `inline_singular=True` like in this code:

```python
import bprint

class DeeplyNested:
    value = [1, 2, 3]

class Something:
    deeply_nested = DeeplyNested()

class Test:
    key = "value"
    something = Something()

bprint.bprint(Test())
bprint.bprint(Test(), inline_singular=True)
```

This is useful for deeply nested objects like those from Telegram (using Telethon).